### PR TITLE
Update dockerfile and prepare script for cloning kale workshop branch and generating user ssh keys

### DIFF
--- a/docker-images/notebook-kubeflow/Dockerfile
+++ b/docker-images/notebook-kubeflow/Dockerfile
@@ -56,7 +56,7 @@ RUN jupyter labextension install jupyter-leaflet \
                                  @ryantam626/jupyterlab_code_formatter \
                                  dask-labextension
 
-RUN git clone https://github.com/kubeflow-kale/jupyterlab-kubeflow-kale.git \
+RUN git clone -b kubecon-workshop https://github.com/kubeflow-kale/jupyterlab-kubeflow-kale.git \
     && cd jupyterlab-kubeflow-kale \
     && jlpm install \
     && jlpm run build \

--- a/docker-images/notebook-kubeflow/Dockerfile
+++ b/docker-images/notebook-kubeflow/Dockerfile
@@ -73,9 +73,16 @@ RUN jupyter serverextension enable \
                             voila \
                             --sys-prefix
 
-RUN curl https://sdk.cloud.google.com | zsh
-
 USER root
+
+# Install Google Cloud SDK 
+RUN apt-get update \
+    && yes | apt-get install gnupg \
+    && echo "deb http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
+    && apt-get update \
+    && yes | apt-get install google-cloud-sdk 
+    
 COPY prepare.sh /usr/bin/prepare.sh
 RUN chmod +x /usr/bin/prepare.sh
 RUN mkdir /gcs && chown -R $NB_USER /gcs

--- a/docker-images/notebook-kubeflow/prepare.sh
+++ b/docker-images/notebook-kubeflow/prepare.sh
@@ -95,6 +95,7 @@ cd .ssh
 if [ ! -f "id_rsa" ]; then
     echo "SSH keys for user ${USER_CONFIG} not found, generating SSH keys"
     ssh-keygen -t rsa -b 4096 -N '' -f $HOME/.ssh/id_rsa 
+    chmod 400 $HOME/.ssh/id_rsa
     eval "$(ssh-agent -s)" 
     ssh-add $HOME/.ssh/id_rsa 
     cd ..

--- a/docker-images/notebook-kubeflow/prepare.sh
+++ b/docker-images/notebook-kubeflow/prepare.sh
@@ -88,8 +88,9 @@ gcloud auth activate-service-account ${SERVICE_ACCOUNT} --key-file=key.json
 gcloud config set project ${PROJECT}
 
 # Generating or mounting ssh keys for user
+export USER_KEY_BUCKET=user_key_bucket
 mkdir .ssh
-gsutil rsync -r gs://user_key_bucket/${USER_CONFIG} .ssh
+gsutil rsync -r gs://${USER_KEY_BUCKET}/${USER_CONFIG} .ssh
 cd .ssh
 if [ ! -f "id_rsa" ]; then
     echo "SSH keys for user ${USER_CONFIG} not found, generating SSH keys"

--- a/docker-images/notebook-kubeflow/prepare.sh
+++ b/docker-images/notebook-kubeflow/prepare.sh
@@ -95,13 +95,13 @@ cd .ssh
 if [ ! -f "id_rsa" ]; then
     echo "SSH keys for user ${USER_CONFIG} not found, generating SSH keys"
     ssh-keygen -t rsa -b 4096 -N '' -f $HOME/.ssh/id_rsa 
-    chmod 400 $HOME/.ssh/id_rsa
     eval "$(ssh-agent -s)" 
     ssh-add $HOME/.ssh/id_rsa 
     cd ..
     gsutil rsync -r .ssh gs://user_key_bucket/${USER_CONFIG}
 fi
 cd ..
+chmod 400 $HOME/.ssh/id_rsa
 
 jupyter lab --notebook-dir=/home/jovyan --ip=0.0.0.0 --no-browser --allow-root --port=8888 --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.allow_origin='*' --NotebookApp.base_url=$NB_PREFIX
 


### PR DESCRIPTION
What I updated:

- Add `-b kubecon-workshop` tag when cloning the `jupyterlab-kubeflow-kale` project to make sure that we are using the workshop version. 
- Installing and initialize `gcloud SDK`
This is done by creating service account private keys to avoid directly use `gcloud init`, as this prompts users to login.
- Generate bucket folder automatically for new coming user under the user namespace name.
- Generate `ssh keys` for user to enable private git repository cloning. 
This is done by cloning the user folder in `gs://user_key_bucket`, keys will be generated only if the respective folder is empty, otherwise keys will be mounted into the local `.ssh` folder.
- Image containing changes are pushed into `idalab/kube_user:hong_dev_sshconfig` registry, and once successfully merged into `idalab/kube_user:latest`