### PR TITLE
Update prepare.sh to mount practical skills and project template

### DIFF
--- a/docker-images/notebook-kubeflow/prepare.sh
+++ b/docker-images/notebook-kubeflow/prepare.sh
@@ -34,27 +34,6 @@ echo "Move configs that do not live in home dir"
 mkdir -p /home/$NB_USER/.jupyter && mv /home/$NB_USER/jupyter_notebook_config.py /home/$NB_USER/.jupyter
 mkdir -p /opt/conda/share/jupyter/lab/settings && mv /home/$NB_USER/overrides.json /opt/conda/share/jupyter/lab/settings
 
-
-echo "Copy data science handbook notebooks"
-if [ -z "$EXAMPLES_GIT_URL" ]; then
-    export EXAMPLES_GIT_URL=https://github.com/idalab-de/PythonDataScienceHandbook
-fi
-rmdir examples &> /dev/null # deletes directory if empty, in favour of fresh clone
-if [ ! -d "examples" ]; then
-  mkdir examples
-  git clone $EXAMPLES_GIT_URL examples
-fi
-
-cd examples
-git remote set-url origin $EXAMPLES_GIT_URL
-git fetch origin
-git reset --hard origin/master
-git merge --strategy-option=theirs origin/master
-if [ ! -f DONT_SAVE_ANYTHING_HERE.md ]; then
-  echo "Files in this directory should be treated as read-only"  > DONT_SAVE_ANYTHING_HERE.md
-fi
-
-cd ..
 mkdir -p work
 
 if [ -e "/opt/app/environment.yml" ]; then
@@ -86,6 +65,22 @@ mkdir .service_account
 gcloud iam service-accounts keys create --iam-account ${SERVICE_ACCOUNT} $HOME/.service_account/KEY.json 
 gcloud auth activate-service-account ${SERVICE_ACCOUNT} --key-file=key.json 
 gcloud config set project ${PROJECT}
+
+# Mounting practical skills and project template repositories
+export PRACTICALSKILLS_GIT_URL=bitbucket_idalab_idalab-practicalskills
+export NOTEBOOK_GIT_URL=https://github.com/idalab-de/PythonDataScienceHandbook.git
+export TEMPLATE_GIT_URL=bitbucket_idalab_idalab-project-template
+if [ ! -d "practical-skills" ]; then
+    gcloud source repos clone ${PRACTICALSKILLS_GIT_URL} practical-skills --project=${PROJECT} 
+    cd practical-skills/notebooks
+    rm -rf PythonDataScienceHandbook
+    git clone ${NOTEBOOK_GIT_URL}
+    cd ~
+fi
+
+if [ ! -d "project-template" ]; then
+    gcloud source repos clone ${TEMPLATE_GIT_URL} project-template --project=${PROJECT}
+fi
 
 # Generate key folder automatically for new user
 export USER_KEY_BUCKET=user_key_bucket


### PR DESCRIPTION
Mount `practical-skills` and `project-template` repositories at server initialization:

- Currently they are private Bitbucket repos and being mirrored to Google Source Repository under the `idalab-kube` project. As we have Cloud SDK already installed, the repos can be "cloned" by using  `gcloud source repo`. 

- Delete `example` folder which clones `PythonDataScienceHandbook` repo due to duplicates.
- Test image `idalab/kube_user:hong_dev_clonerepo`