### PR TITLE
Add git committer information and install gcsFUSE

### DIFF
--- a/docker-images/notebook-kubeflow/Dockerfile
+++ b/docker-images/notebook-kubeflow/Dockerfile
@@ -87,6 +87,16 @@ RUN apt-get update \
     && apt-get update \
     && yes | apt-get install google-cloud-sdk
 
+# Install gcsFUSE
+RUN apt-get update \
+    && apt-get install  -yq lsb \
+    && export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s` \
+    && echo "deb http://packages.cloud.google.com/apt $GCSFUSE_REPO main" | tee /etc/apt/sources.list.d/gcsfuse.list \
+    && apt-get install gnupg \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
+    && apt-get update \
+    && apt-get install gcsfuse 
+
 COPY prepare.sh /usr/bin/prepare.sh
 RUN chmod +x /usr/bin/prepare.sh
 RUN mkdir /gcs && chown -R $NB_USER /gcs

--- a/docker-images/notebook-kubeflow/Dockerfile
+++ b/docker-images/notebook-kubeflow/Dockerfile
@@ -47,7 +47,7 @@ RUN pip install pipenv \
                 --upgrade --no-cache-dir \
                 --upgrade-strategy only-if-needed
 
-RUN pip install git+https://github.com/kubeflow-kale/kale.git@kubecon-workshop
+RUN pip install kubeflow-kale
 
 RUN jupyter labextension install jupyter-leaflet \
                                  @jupyterlab/git \
@@ -60,11 +60,7 @@ RUN jupyter labextension install jupyter-leaflet \
                                  jupyterlab-plotly@1.3.0 \
                                  jupyterlab-dash
 
-RUN git clone -b kubecon-workshop https://github.com/kubeflow-kale/jupyterlab-kubeflow-kale.git \
-    && cd jupyterlab-kubeflow-kale \
-    && jlpm install \
-    && jlpm run build \
-    && jupyter labextension install .
+RUN jupyter labextension install kubeflow-kale-launcher
 
 RUN jupyter serverextension enable --py nbserverproxy \
                                         jupyterlab \

--- a/docker-images/notebook-kubeflow/prepare.sh
+++ b/docker-images/notebook-kubeflow/prepare.sh
@@ -30,6 +30,12 @@ else
     cp -r user-config/defaults/. /home/$NB_USER
 fi
 
+# Set git committer name & email globally
+export USER_NAME=$(echo ${USER_CONFIG} | tr "-" " ")
+export USER_EMAIL=$(echo ${USER_NAME}@idalab.de | tr " " ".")
+git config --global user.email ${USER_EMAIL}
+git config --global user.name ${USER_NAME}
+
 echo "Move configs that do not live in home dir"
 mkdir -p /home/$NB_USER/.jupyter && mv /home/$NB_USER/jupyter_notebook_config.py /home/$NB_USER/.jupyter
 mkdir -p /opt/conda/share/jupyter/lab/settings && mv /home/$NB_USER/overrides.json /opt/conda/share/jupyter/lab/settings


### PR DESCRIPTION
- Update prepare script to set default git committer `name` and `email (idalab)` globally for the convenience of users.
- Update Dockerfile to install `gcsFUSE`.
- Update the installation of Kale with master branch: `Kale v0.4.0` and `Kale launcher v1.4.1`