### PR TITLE
Update base image version to 1.2.5; Install jupyterlab extension debu…

### DIFF
--- a/docker-images/notebook-kubeflow/Dockerfile
+++ b/docker-images/notebook-kubeflow/Dockerfile
@@ -2,6 +2,7 @@ FROM idalab/kube_worker:lab-1.2.5
 
 USER root
 RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
     apt-get install \
     -yq \
     --no-install-recommends \
@@ -13,6 +14,7 @@ RUN apt-get update && \
     vim \
     man \
     tree \
+    tzdata \
     openssh-server \
     build-essential \
     bash-completion \

--- a/docker-images/notebook-kubeflow/Dockerfile
+++ b/docker-images/notebook-kubeflow/Dockerfile
@@ -64,7 +64,12 @@ RUN jupyter labextension install jupyter-leaflet \
                                  jupyterlab-plotly@1.5.0 \
                                  jupyterlab-dash \
                                  @jupyterlab/debugger \
-                                 @techrah/text-shortcuts
+                                 @techrah/text-shortcuts \
+                                 @telamonian/theme-darcula \
+                                 @karosc/jupyterlab_dracula \
+                                 jupyterlab-topbar-extension \
+                                 jupyterlab-topbar-text \
+                                 jupyterlab-theme-toggle
 
 RUN jupyter labextension install kubeflow-kale-launcher
 

--- a/docker-images/notebook-kubeflow/Dockerfile
+++ b/docker-images/notebook-kubeflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM idalab/kube_worker:lab-1.1.3
+FROM idalab/kube_worker:lab-1.2.5
 
 USER root
 RUN apt-get update && \
@@ -35,6 +35,8 @@ RUN conda install --yes \
     voila \
     black \
     jupyterlab_code_formatter \
+    ptvsd \
+    xeus-python notebook \
     && conda clean --all -f -y
 
 RUN pip install --upgrade pip
@@ -58,7 +60,9 @@ RUN jupyter labextension install jupyter-leaflet \
                                  dask-labextension \
                                  plotlywidget@1.5.0 \
                                  jupyterlab-plotly@1.5.0 \
-                                 jupyterlab-dash
+                                 jupyterlab-dash \
+                                 @jupyterlab/debugger \
+                                 @techrah/text-shortcuts
 
 RUN jupyter labextension install kubeflow-kale-launcher
 

--- a/docker-images/notebook-kubeflow/prepare.sh
+++ b/docker-images/notebook-kubeflow/prepare.sh
@@ -30,6 +30,12 @@ else
     cp -r user-config/defaults/. /home/$NB_USER
 fi
 
+# Copy r shortcuts setting to enable jupyterlab extension 
+if [ ! -d .jupyter/lab/user-settings ]; then
+    mkdir -p .jupyter/lab/user-settings/@jupyterlab/shortcuts-extension
+    cp user-config/R-user/shortcuts.jupyterlab-settings .jupyter/lab/user-settings/@jupyterlab/shortcuts-extension/.
+fi
+
 # Set git committer name & email globally
 export USER_NAME=$(echo ${USER_CONFIG} | tr "-" " ")
 export USER_EMAIL=$(echo ${USER_NAME}@idalab.de | tr " " ".")

--- a/docker-images/notebook-kubeflow/prepare.sh
+++ b/docker-images/notebook-kubeflow/prepare.sh
@@ -36,6 +36,11 @@ if [ ! -d .jupyter/lab/user-settings ]; then
     cp user-config/R-user/shortcuts.jupyterlab-settings .jupyter/lab/user-settings/@jupyterlab/shortcuts-extension/.
 fi
 
+# Re-configure Olson timezone database  
+echo "Europe/Berlin" | sudo tee /etc/timezone
+sudo rm -f /etc/localtime
+sudo dpkg-reconfigure -f noninteractive tzdata
+
 # Set git committer name & email globally
 export USER_NAME=$(echo ${USER_CONFIG} | tr "-" " ")
 export USER_EMAIL=$(echo ${USER_NAME}@idalab.de | tr " " ".")

--- a/docker-images/notebook-kubeflow/prepare.sh
+++ b/docker-images/notebook-kubeflow/prepare.sh
@@ -47,6 +47,10 @@ export USER_EMAIL=$(echo ${USER_NAME}@idalab.de | tr " " ".")
 git config --global user.email ${USER_EMAIL}
 git config --global user.name ${USER_NAME}
 
+# Increase npm timeout setting 
+npm install -g yarn@1.15.2 
+yarn install --cwd /opt/conda/share/jupyter/lab/staging --network-timeout 1000000
+
 echo "Move configs that do not live in home dir"
 mkdir -p /home/$NB_USER/.jupyter && mv /home/$NB_USER/jupyter_notebook_config.py /home/$NB_USER/.jupyter
 mkdir -p /opt/conda/share/jupyter/lab/settings && mv /home/$NB_USER/overrides.json /opt/conda/share/jupyter/lab/settings

--- a/docker-images/notebook-kubeflow/worker-image/Dockerfile
+++ b/docker-images/notebook-kubeflow/worker-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:lab-1.1.3
+FROM jupyter/base-notebook:lab-1.2.5
 
 USER root
 RUN apt-get update && \


### PR DESCRIPTION
Some changes to improve user experience:

- Update notebook base image version from `1.1.3` to `1.2.5`.
- Install `xeus-python` to enable xpython kernel. 
- Install `jupyterlab/debugger` extension and ptvsd for debugger visualization.
- Install `text-shortcuts` to support user customised shortcuts for R kernel, mount shortcut settings from user-config repo.
- Install and re-configure `Olson database`, motivated by https://github.com/tidyverse/readr/issues/952
- Increase npm timeout settings to enable users install lab extension from within notebook. This is a fix of JupyterLab issue `RuntimeError: npm dependencies failed to install`
- Install theme related lab extensions `darcula`, `theme-toggle` and `topbar-text`.

Test image can be found at `gcr.io/idalab-kube/kube-user@sha256:6ec10c902572e1acaeee5cdabd7324caa7f3688fef8f74e025738b6d0955c3ad`